### PR TITLE
fix: Provide protocol header expected by browser

### DIFF
--- a/packages/nhost_gql_links/lib/src/links.dart
+++ b/packages/nhost_gql_links/lib/src/links.dart
@@ -115,7 +115,8 @@ Link webSocketLinkForNhost(
   WebSocketChannel? channel;
   final channelGenerator = testChannelGenerator != null
       ? (() async => channel = await testChannelGenerator()) as ChannelGenerator
-      : () => channel = WebSocketChannel.connect(wsEndpointUri);
+      : () => channel =
+          WebSocketChannel.connect(wsEndpointUri, protocols: ['graphql-ws']);
 
   // If authentication state changes, we reconnect the socket, which will also
   // re-evaluate the initialPayload to provide the auth header if available.


### PR DESCRIPTION
Hasura sends back a header indicating which line protocol is going to be used. In browsers, if a matching header is not sent on the request, the browser will reject the handshake.

This differs from the behavior in Dart's native websocket, which does not perform this validation.

Fixes #15 