### PR TITLE
fix: Keep auth refresh-locked when a refresh is already in process

### DIFF
--- a/packages/nhost_sdk/lib/src/auth.dart
+++ b/packages/nhost_sdk/lib/src/auth.dart
@@ -548,14 +548,22 @@ class Auth {
         },
         responseDeserializer: Session.fromJson,
       );
-    } on ApiException catch (e) {
+    } on ApiException catch (e, st) {
+      debugPrint('API exception during token refresh');
+      debugPrint(e);
+      debugPrint(st);
+
       if (e.statusCode == unauthorizedStatus) {
         await logout();
         return;
       } else {
         return; // Silent fail
       }
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Exception during token refresh');
+      debugPrint(e);
+      debugPrint(st);
+
       return;
     } finally {
       // Release lock

--- a/packages/nhost_sdk/lib/src/auth.dart
+++ b/packages/nhost_sdk/lib/src/auth.dart
@@ -528,15 +528,16 @@ class Auth {
       return;
     }
 
+    // Set lock to avoid two refresh token request being sent at the same time
+    // with the same token. If so, the last request will fail because the
+    // first request used the refresh token
+    if (_refreshTokenLock) {
+      debugPrint('Refresh token already in transit. Halting this request.');
+      return;
+    }
+
     Session? res;
     try {
-      // Set lock to avoid two refresh token request being sent at the same time
-      // with the same token. If so, the last request will fail because the
-      // first request used the refresh token
-      if (_refreshTokenLock) {
-        debugPrint('Refresh token already in transit. Halting this request.');
-        return;
-      }
       _refreshTokenLock = true;
 
       // Make refresh token request


### PR DESCRIPTION
Previously, there was a `return` in a `try` whose `finally` unlocked the auth object to attempt another token refresh.

We will now return if a token refresh is already in process, without affecting the lock state.

Related to https://github.com/nhost/nhost-dart/issues/21 (won't fix things, but should be clearer about reporting problems)