### PR TITLE
feat: Add `logging` support to SDK and link packages

### DIFF
--- a/packages/nhost_gql_links/lib/src/logging.dart
+++ b/packages/nhost_gql_links/lib/src/logging.dart
@@ -1,0 +1,25 @@
+import 'package:gql/ast.dart';
+import 'package:logging/logging.dart';
+
+/// Logs package events
+final log = Logger('nhost.gql_links');
+
+/// Extension to expose a method for the logging of operations
+extension OperationDefinitionListLogging on List<OperationDefinitionNode> {
+  String toLogString() {
+    final sb = StringBuffer();
+    sb
+      ..write('(')
+      ..write(map((def) =>
+          describeEnum(def.type.toString()) +
+          (def.name?.value != null ? ' "${def.name!.value}"' : '')).join(', '))
+      ..write(')');
+
+    return sb.toString();
+  }
+}
+
+/// Strips the type name from an enum value's toString.
+String describeEnum(String enumString) {
+  return enumString.substring(enumString.indexOf('.') + 1);
+}

--- a/packages/nhost_gql_links/pubspec.yaml
+++ b/packages/nhost_gql_links/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   gql_websocket_link: ^0.3.1
   gql: ^0.13.0
   http: ^0.13.1
+  logging: ^1.0.1
   meta: ^1.3.0
   web_socket_channel: ^2.0.0
 

--- a/packages/nhost_sdk/lib/nhost_sdk.dart
+++ b/packages/nhost_sdk/lib/nhost_sdk.dart
@@ -1,6 +1,7 @@
 library nhost_sdk;
 
 import 'package:http/http.dart' as http;
+import 'package:nhost_sdk/src/logging.dart';
 
 import 'src/auth.dart';
 import 'src/auth_store.dart';
@@ -12,6 +13,7 @@ export 'src/api/auth_api_types.dart';
 export 'src/api/storage_api_types.dart';
 export 'src/auth.dart';
 export 'src/auth_store.dart';
+export 'src/logging.dart' show debugLogNhostErrorsToConsole;
 export 'src/storage.dart';
 
 /// API client for accessing Nhost's authentication and storage APIs.
@@ -75,7 +77,9 @@ class NhostClient {
         _refreshToken = refreshToken,
         _autoLogin = autoLogin ?? true,
         _refreshInterval = tokenRefreshInterval,
-        _httpClient = httpClientOverride;
+        _httpClient = httpClientOverride {
+    initializeLogging();
+  }
 
   /// The Nhost project's backend URL.
   final String baseUrl;

--- a/packages/nhost_sdk/lib/src/api/api_client.dart
+++ b/packages/nhost_sdk/lib/src/api/api_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:meta/meta.dart';
+import 'package:nhost_sdk/src/logging.dart';
 
 import '../foundation/uri.dart';
 import '../http.dart';
@@ -167,6 +168,8 @@ class ApiClient {
 
     // If the status is not in the success range, throw.
     if (response.statusCode < 200 || response.statusCode >= 300) {
+      log.finer('API client encountered a failure, '
+          'url=${request.url} status=${response.statusCode}');
       throw ApiException(request.url, responseBody, request, response);
     }
 

--- a/packages/nhost_sdk/lib/src/debug.dart
+++ b/packages/nhost_sdk/lib/src/debug.dart
@@ -1,1 +1,0 @@
-void debugPrint(Object? message) => print('$message');

--- a/packages/nhost_sdk/lib/src/logging.dart
+++ b/packages/nhost_sdk/lib/src/logging.dart
@@ -1,0 +1,34 @@
+import 'package:logging/logging.dart';
+
+/// Logs package events
+final log = Logger('nhost.sdk');
+
+/// When `true`, errors will be printed to the console via `Logger.root` (from
+/// the `logging` package). When `false`, no logging will take place.
+///
+/// Nhost uses the `logging` package, which means that your application can be
+/// configured to change what is logged, and where it is logged to. If you are
+/// configuring logging yourself, it probably makes sense to set this flag to
+/// `false`.
+bool debugLogNhostErrorsToConsole = true;
+
+/// Initializes logging if it hasn't already been.
+void initializeLogging() {
+  if (_loggingInitialized || !debugLogNhostErrorsToConsole) {
+    return;
+  }
+
+  Logger.root.onRecord.listen((record) {
+    if (debugLogNhostErrorsToConsole &&
+        record.level >= Level.SEVERE &&
+        record.loggerName.startsWith('nhost.')) {
+      print('${record.time.toIso8601String()} [nhost] ${record.message}');
+      if (record.error != null) print('${record.error}');
+      if (record.stackTrace != null) print(record.stackTrace);
+    }
+  });
+  _loggingInitialized = true;
+}
+
+/// `true` if we've created an error logger
+bool _loggingInitialized = false;

--- a/packages/nhost_sdk/pubspec.yaml
+++ b/packages/nhost_sdk/pubspec.yaml
@@ -9,9 +9,10 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  http: ^0.13.0
   http_parser: ^4.0.0
+  http: ^0.13.0
   jwt_decoder: ^2.0.0
+  logging: ^1.0.1
   meta: ^1.0.0
   path: ^1.0.0
   pedantic: ^1.8.0


### PR DESCRIPTION
Introduces use of the [logging package](https://pub.dev/packages/logging), so that we can enable trace-level logging to more easily debug issues as they occur.

Logging can be enabled by introducing a root logger to your application, setting `hierarchicalLoggingEnabled = true`, and configuring `Logger('nhost').level = LogLevel.ALL` (or whatever your desired log level might be).

Most of the logging is performed at the `LogLevel.FINEST` level.

By default, the SDK's loggers are configured to print SEVERE>= log records to the console. If this behavior is not desired (because you're seeing duplicate log entries, for example), set `debugLogNhostErrorsToConsole` to `false`, and handle them any way you want in either `Logger('nhost')` or `Logger.root`.

Fixes #23 