### PR TITLE
Fix todos example

### DIFF
--- a/packages/nhost_flutter_auth/lib/src/provider.dart
+++ b/packages/nhost_flutter_auth/lib/src/provider.dart
@@ -30,7 +30,8 @@ class NhostAuthProvider extends InheritedNotifier<_AuthNotifier> {
 /// A [Listenable] that notifies when Nhost authentication states changes
 class _AuthNotifier extends ChangeNotifier implements ValueListenable<Auth> {
   _AuthNotifier(Auth auth) : _auth = auth {
-    _unsubscribeAuthListener = _auth.addTokenChangedCallback(notifyListeners);
+    _unsubscribeAuthListener =
+        _auth.addAuthStateChangedCallback((_) => notifyListeners());
   }
 
   final Auth _auth;

--- a/packages/nhost_flutter_auth/test/nhost_flutter_auth_test.dart
+++ b/packages/nhost_flutter_auth/test/nhost_flutter_auth_test.dart
@@ -98,7 +98,7 @@ void main() {
       expect(buildCount, 1);
 
       // Emulate an auth state change, then pump the engine
-      mockAuth.triggerStateChange();
+      mockAuth.triggerStateChange(AuthenticationState.loggedOut);
       await tester.pump();
 
       // The state change should result in a second build
@@ -122,19 +122,20 @@ void main() {
 }
 
 class MockAuth extends Mock implements Auth {
-  final List<TokenChangedCallback> _tokenChangedCallbacks = [];
+  final List<AuthStateChangedCallback> _tokenChangedCallbacks = [];
 
   @override
-  UnsubscribeDelegate addTokenChangedCallback(TokenChangedCallback callback) {
+  UnsubscribeDelegate addAuthStateChangedCallback(
+      AuthStateChangedCallback callback) {
     _tokenChangedCallbacks.add(callback);
     return () {
       _tokenChangedCallbacks.removeWhere((element) => element == callback);
     };
   }
 
-  void triggerStateChange() {
+  void triggerStateChange(AuthenticationState authState) {
     for (final callback in _tokenChangedCallbacks) {
-      callback();
+      callback(authState);
     }
   }
 }

--- a/packages/nhost_flutter_graphql/example/lib/todos_quick_start_example.dart
+++ b/packages/nhost_flutter_graphql/example/lib/todos_quick_start_example.dart
@@ -121,6 +121,11 @@ class TodosPage extends StatelessWidget {
       builder: (result, {fetchMore, refetch}) {
         if (result.isLoading) return Text('Loading…');
         if (!result.isConcrete) return SizedBox();
+        if (result.hasException) {
+          return Text('Error encountered while loading todos. Did you setup '
+              'your backend using the quick-start at '
+              'https://docs.nhost.io/quick-start?');
+        }
 
         final todos = (result.data['todos'] as List)
             .map((json) => Todo.fromJson(json))

--- a/packages/nhost_flutter_graphql/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/nhost_flutter_graphql/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import connectivity_macos
+import connectivity_plus_macos
 import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/packages/nhost_flutter_graphql/example/macos/Podfile.lock
+++ b/packages/nhost_flutter_graphql/example/macos/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - connectivity_macos (0.0.1):
+  - connectivity_plus_macos (0.0.1):
     - FlutterMacOS
     - Reachability
   - FlutterMacOS (1.0.0)
@@ -8,7 +8,7 @@ PODS:
   - Reachability (3.2)
 
 DEPENDENCIES:
-  - connectivity_macos (from `Flutter/ephemeral/.symlinks/plugins/connectivity_macos/macos`)
+  - connectivity_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
 
@@ -17,19 +17,19 @@ SPEC REPOS:
     - Reachability
 
 EXTERNAL SOURCES:
-  connectivity_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_macos/macos
+  connectivity_plus_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
 
 SPEC CHECKSUMS:
-  connectivity_macos: 9f30e9d0e67a0bc08a0c563ee82310b51ca6e818
+  connectivity_plus_macos: 3da1605dc99d44cf06fb6852de4ed26ecef3cabc
   FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
   path_provider_macos: a0a3fd666cb7cd0448e936fb4abad4052961002b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/packages/nhost_flutter_graphql/lib/src/graphql_provider.dart
+++ b/packages/nhost_flutter_graphql/lib/src/graphql_provider.dart
@@ -108,7 +108,12 @@ class _NhostGraphQLProviderState extends State<NhostGraphQLProvider> {
   Widget build(BuildContext context) {
     return GraphQLProvider(
       client: clientNotifier as ValueNotifier<GraphQLClient>,
-      child: widget.child,
+      child: widget.child != null
+          ? NhostAuthProvider(
+              auth: currentNhostAuth,
+              child: widget.child!,
+            )
+          : null,
     );
   }
 }

--- a/packages/nhost_sdk/README.md
+++ b/packages/nhost_sdk/README.md
@@ -43,15 +43,7 @@ void main() async {
 
 ```yaml
 dependencies:
-  nhost_sdk: ^1.0.0
-```
-
-For people affected by the Metal jank issues on iOS, we support Flutter 1.22.4
-as well:
-
-```yaml
-dependencies:
-  nhost_sdk: ^0.8.0
+  nhost_sdk: ^2.0.0
 ```
 
 ## 🔥 More Dart & Flutter packages from Nhost

--- a/packages/nhost_sdk/lib/src/auth.dart
+++ b/packages/nhost_sdk/lib/src/auth.dart
@@ -19,7 +19,8 @@ typedef TokenChangedCallback = void Function();
 /// Signature for callbacks that respond to authentication changes.
 ///
 /// Registered via [Auth.addAuthStateChangedCallback].
-typedef AuthStateChangedCallback = void Function({required bool authenticated});
+typedef AuthStateChangedCallback = void Function(
+    AuthenticationState authenticationState);
 
 /// Signature for functions that remove their associated callback when called.
 typedef UnsubscribeDelegate = void Function();
@@ -148,11 +149,10 @@ class Auth {
     }
   }
 
-  void _onAuthStateChanged({required bool authenticated}) {
-    log.finest(
-        'Calling auth state change callbacks, authenticated=$authenticated');
+  void _onAuthStateChanged(AuthenticationState authState) {
+    log.finest('Calling auth state change callbacks, authState=$authState');
     for (final authChangedFunction in _authChangedFunctions) {
-      authChangedFunction(authenticated: authenticated);
+      authChangedFunction(authState);
     }
   }
 
@@ -542,6 +542,7 @@ class Auth {
     if (refreshToken == null) {
       log.finest('No refresh token. Halting request.');
       _loading = false;
+      _onAuthStateChanged(authenticationState);
       return;
     }
 
@@ -631,7 +632,7 @@ class Auth {
 
     _onTokenChanged();
     if (previouslyAuthenticated != AuthenticationState.loggedIn) {
-      _onAuthStateChanged(authenticated: true);
+      _onAuthStateChanged(AuthenticationState.loggedIn);
     }
   }
 
@@ -658,7 +659,7 @@ class Auth {
 
     _loading = false;
     _onTokenChanged();
-    _onAuthStateChanged(authenticated: false);
+    _onAuthStateChanged(AuthenticationState.loggedOut);
   }
 
   //#endregion

--- a/packages/nhost_sdk/lib/src/auth.dart
+++ b/packages/nhost_sdk/lib/src/auth.dart
@@ -18,7 +18,7 @@ typedef TokenChangedCallback = void Function();
 
 /// Signature for callbacks that respond to authentication changes.
 ///
-/// Registered via [Auth.addTokenChangedCallback].
+/// Registered via [Auth.addAuthStateChangedCallback].
 typedef AuthStateChangedCallback = void Function({required bool authenticated});
 
 /// Signature for functions that remove their associated callback when called.

--- a/packages/nhost_sdk/test/auth_test.dart
+++ b/packages/nhost_sdk/test/auth_test.dart
@@ -202,34 +202,33 @@ void main() async {
   });
 
   group('authentication state callbacks', () {
-    bool? authStateVar = false;
+    AuthenticationState? authStateVar;
     late UnsubscribeDelegate unsubscribe;
 
     setUp(() {
-      authStateVar = false;
-      unsubscribe =
-          auth.addAuthStateChangedCallback(({required authenticated}) {
-        authStateVar = authenticated;
+      authStateVar = AuthenticationState.inProgress;
+      unsubscribe = auth.addAuthStateChangedCallback((authState) {
+        authStateVar = authState;
       });
     });
 
     test('should be called on login', () async {
       await registerTestUser(auth);
       await auth.login(email: testEmail, password: testPassword);
-      expect(authStateVar, true);
+      expect(authStateVar, AuthenticationState.loggedIn);
     });
 
     test('should be called on logout', () async {
       await registerTestUser(auth);
       await auth.logout();
-      expect(authStateVar, false);
+      expect(authStateVar, AuthenticationState.loggedOut);
     });
 
     test('should not be called once unsubscribed', () async {
       await registerTestUser(auth);
       unsubscribe();
       await auth.login(email: testEmail, password: testPassword);
-      expect(authStateVar, false);
+      expect(authStateVar, AuthenticationState.loggedOut);
     });
   });
 


### PR DESCRIPTION
At some point, the `NhostGraphQLProvider` stopped providing authentication state down-tree. I also noticed that finer-grained authentication notifications were required to have the `NhostAuthProvider` react to auth state appropriately.