### PR TITLE
Change early return for clear session only if current state is alread…

### DIFF
--- a/packages/nhost_sdk/lib/src/auth.dart
+++ b/packages/nhost_sdk/lib/src/auth.dart
@@ -650,7 +650,10 @@ class Auth {
     }
 
     // Early exit
-    if (authenticationState != AuthenticationState.loggedIn) {
+    // There could be case when the authenticationState is inProgress and logOut is called
+    // For example, refresh token expired
+    // In that case it is important to to clear out the session and remove the refresh token from the storage
+    if (authenticationState == AuthenticationState.loggedOut) {
       return;
     }
 

--- a/packages/nhost_sdk/test/auth_test.dart
+++ b/packages/nhost_sdk/test/auth_test.dart
@@ -171,7 +171,7 @@ void main() async {
   });
 
   group('logout', () {
-    // All logout tests log a user in first
+    // All logout tests log in a user in first
     setUp(() async {
       await registerAndLoginBasicUser(auth);
     });

--- a/packages/nhost_sdk/test/auth_test.dart
+++ b/packages/nhost_sdk/test/auth_test.dart
@@ -171,7 +171,7 @@ void main() async {
   });
 
   group('logout', () {
-    // All logout tests log in a user in first
+    // All logout tests log a user in first
     setUp(() async {
       await registerAndLoginBasicUser(auth);
     });

--- a/packages/nhost_sdk/test/test_helpers.dart
+++ b/packages/nhost_sdk/test/test_helpers.dart
@@ -14,7 +14,7 @@ Future<void> registerTestUser(Auth auth) async {
 }
 
 // Register and logs in a basic user for test setup. The auth object will be
-// left in a logged out state.
+// left in a logged in state.
 Future<void> registerAndLoginBasicUser(Auth auth) async {
   await auth.register(email: defaultTestEmail, password: defaultTestPassword);
 }


### PR DESCRIPTION
…y logged out

### Scope of change
Right now as described in the issue https://github.com/nhost/nhost-dart/issues/32, if the refresh token expires then when the Auth is initialized, it is in AuthenticationState.inProgress state and since the refresh token is expired, the package tries to log the user out so that they can be logged in back which would generate a new refresh token. However due to the false early return condition the user doesn't fully get logged out, since the session is not clear and refresh token is not deleted from the local storage. This pr is to fix that and only do early return if the user already has been logged out before.

### Testing
Unfortunately most of the authentication  tests of this package are more integration tests than unit tests. Ideally i would like to be able to mock out the dependencies of Auth like authStore, session, httpClient, etc and make sure in unit tests that the correct methods of those dependencies are called. For example in this case make sure that session.clear is called and authStore.remove is called if the auth state is not loggedOut. However such tests do not exist right now. 