### PR TITLE
docs: Remove mention of older Flutter support from READMEs

### DIFF
--- a/packages/nhost_flutter_auth/README.md
+++ b/packages/nhost_flutter_auth/README.md
@@ -14,14 +14,6 @@ dependencies:
   nhost_flutter_auth: ^1.0.0
 ```
 
-For people affected by the Metal jank issues on iOS, we support Flutter 1.22.4
-as well:
-
-```yaml
-dependencies:
-  nhost_flutter_auth: ^0.3.0
-```
-
 ## 🔥 More Dart & Flutter packages from Nhost
 
 * [nhost_sdk](https://pub.dev/packages/nhost_sdk)

--- a/packages/nhost_flutter_graphql/README.md
+++ b/packages/nhost_flutter_graphql/README.md
@@ -14,14 +14,6 @@ dependencies:
   nhost_flutter_graphql: ^1.0.0
 ```
 
-For people affected by the Metal jank issues on iOS, we support Flutter 1.22.4
-as well:
-
-```yaml
-dependencies:
-  nhost_flutter_graphql: ^0.1.0
-```
-
 ## 🔥 More Dart & Flutter packages from Nhost
 
 * [nhost_sdk](https://pub.dev/packages/nhost_sdk)

--- a/packages/nhost_graphql_adapter/README.md
+++ b/packages/nhost_graphql_adapter/README.md
@@ -19,14 +19,6 @@ dependencies:
   nhost_graphql_adapter: ^1.0.0
 ```
 
-For people affected by the Metal jank issues on iOS, we support Flutter 1.22.4
-as well:
-
-```yaml
-dependencies:
-  nhost_graphql_adapter: ^0.6.0
-```
-
 ## 🔥 More Dart & Flutter packages from Nhost
 
 * [nhost_sdk](https://pub.dev/packages/nhost_sdk)


### PR DESCRIPTION
The Metal-related jank issues have largely been resolved by the Flutter team, so its mention is no longer required.