### PR TITLE
Add support for reporting upload progress

### DIFF
--- a/packages/nhost_sdk/lib/src/api/api_client.dart
+++ b/packages/nhost_sdk/lib/src/api/api_client.dart
@@ -158,8 +158,25 @@ class ApiClient {
       request.headers.addAll(headers);
     }
 
-    final response =
-        await http.Response.fromStream(await _httpClient.send(request));
+    return _handleResponse(
+      await http.Response.fromStream(await _httpClient.send(request)),
+      responseDeserializer: responseDeserializer,
+    );
+  }
+
+  http.Request _newApiRequest(
+    String method,
+    String path, {
+    Map<String, String?>? query,
+  }) =>
+      http.Request(method, baseUrl.extend(path, queryParameters: query))
+        ..encoding = utf8;
+
+  ResponseType _handleResponse<ResponseType>(
+    http.Response response, {
+    JsonDeserializer<ResponseType>? responseDeserializer,
+  }) {
+    final request = response.request!;
     final contentTypeHeader = response.headers['content-type'];
     final isJson =
         contentTypeHeader?.startsWith(_noCharsetJsonContentType.toString()) ==
@@ -182,14 +199,6 @@ class ApiClient {
       return null as ResponseType;
     }
   }
-
-  http.Request _newApiRequest(
-    String method,
-    String path, {
-    Map<String, String?>? query,
-  }) =>
-      http.Request(method, baseUrl.extend(path, queryParameters: query))
-        ..encoding = utf8;
 }
 
 /// Thrown by [ApiClient] to indicate a failed API call.

--- a/packages/nhost_sdk/lib/src/api/storage_api_types.dart
+++ b/packages/nhost_sdk/lib/src/api/storage_api_types.dart
@@ -35,6 +35,12 @@ class FileMetadata {
   /// Additional Nhost-specific metadata associated with this file
   final FileNhostMetadata? nhostMetadata;
 
+  @override
+  String toString() {
+    return 'FileMetadata('
+        'key=$key, contentType=$contentType, contentLength=$contentLength)';
+  }
+
   static FileMetadata fromJson(dynamic json) {
     return FileMetadata(
       // TODO(https://github.com/nhost/hasura-backend-plus/issues/436): In

--- a/packages/nhost_sdk/lib/src/foundation/collection.dart
+++ b/packages/nhost_sdk/lib/src/foundation/collection.dart
@@ -1,0 +1,30 @@
+import 'dart:math' show min;
+
+/// Processes int lists moving through the stream, emitting them as sublists
+/// of length [chunkLength].
+Stream<List<int>> chunkStream(
+  Stream<List<int>> stream, {
+  required int chunkLength,
+}) async* {
+  await for (final data in stream) {
+    if (data.length < chunkLength) {
+      yield data;
+    } else {
+      for (final chunk in chunkList(data, chunkLength)) {
+        yield chunk;
+      }
+    }
+  }
+}
+
+/// Chunks [elements] into sublists of size [chunkSize].
+Iterable<List<T>> chunkList<T>(List<T> elements, int chunkSize) sync* {
+  for (int i = 0; i < elements.length; i += chunkSize) {
+    yield elements.sublist(
+        i,
+        min(
+          i + chunkSize,
+          elements.length,
+        ));
+  }
+}

--- a/packages/nhost_sdk/lib/src/foundation/request.dart
+++ b/packages/nhost_sdk/lib/src/foundation/request.dart
@@ -1,0 +1,15 @@
+import 'package:http/http.dart' as http;
+
+/// An HTTP request whose body is supplied via a [Stream].
+class StreamWrappingRequest extends http.BaseRequest {
+  StreamWrappingRequest(String method, Uri url, this.bodyStream)
+      : super(method, url);
+
+  final Stream<List<int>> bodyStream;
+
+  @override
+  http.ByteStream finalize() {
+    super.finalize();
+    return http.ByteStream(bodyStream);
+  }
+}

--- a/packages/nhost_sdk/lib/src/storage.dart
+++ b/packages/nhost_sdk/lib/src/storage.dart
@@ -41,6 +41,7 @@ class Storage {
     required String filePath,
     required List<int> bytes,
     String contentType = applicationOctetStreamType,
+    UploadProgressCallback? onUploadProgress,
   }) async {
     final file = http.MultipartFile.fromBytes(
       'file',
@@ -54,6 +55,7 @@ class Storage {
       headers: _session.authenticationHeaders,
       files: [file],
       responseDeserializer: FileMetadata.fromJson,
+      onUploadProgress: onUploadProgress,
     );
   }
 
@@ -68,6 +70,7 @@ class Storage {
     required String filePath,
     required String string,
     String contentType = applicationOctetStreamType,
+    UploadProgressCallback? onUploadProgress,
   }) async {
     final file = http.MultipartFile.fromString(
       'file',
@@ -80,10 +83,10 @@ class Storage {
       _objectPath(filePath),
       files: [file],
       headers: {
-        'Content-Type': 'multipart/form-data',
         ..._session.authenticationHeaders,
       },
       responseDeserializer: FileMetadata.fromJson,
+      onUploadProgress: onUploadProgress,
     );
   }
 

--- a/packages/nhost_sdk/pubspec.yaml
+++ b/packages/nhost_sdk/pubspec.yaml
@@ -18,9 +18,10 @@ dependencies:
   path: ^1.0.0
 
 dev_dependencies:
-  betamax: ^1.0.0
+  betamax: ^1.0.7
   fake_async: ^1.0.0
   graphql: ^5.0.0
+  mockito: ^5.0.0
   nock: ^1.0.0
   otp: '>=3.0.0-nullsafety.0 <4.0.0'
   stack_trace: ^1.0.0

--- a/packages/nhost_sdk/test/matchers.dart
+++ b/packages/nhost_sdk/test/matchers.dart
@@ -1,0 +1,34 @@
+import 'package:test_api/expect.dart';
+
+/// Matches when the provided iterable is monotonically increasing.
+const isIncreasing = _IsIncreasingMatcher();
+
+class _IsIncreasingMatcher extends Matcher {
+  const _IsIncreasingMatcher();
+
+  @override
+  Description describe(Description description) =>
+      description.add('is increasing');
+
+  @override
+  bool matches(dynamic item, Map matchState) {
+    if (item is! Iterable) {
+      return false;
+    }
+
+    final list = item.toList();
+    for (final pair in _consecutivePairs(list)) {
+      if (pair[0] > pair[1]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+Iterable<List<T>> _consecutivePairs<T>(List<T> elements) sync* {
+  for (int i = 1; i < elements.length; i++) {
+    yield [elements[i - 1], elements[i]];
+  }
+}


### PR DESCRIPTION
Dart's `HttpClient` doesn't have support for reporting upload progress directly, but I was able to get a pretty good estimation of upload progress by counting bytes as they flow out of the application code and into the socket layer. I chunk the stream first, because otherwise it appears everything is buffered at a lower level.

This doesn't work perfectly. There still appears to be a lot of buffering in the socket layer. 

A possible avenue to smooth out the progress is to disable buffering in the socket (`SocketOption.tcpNoDelay`), but it doesn't feel worth it to explore at this point. I don't _think_ the socket creation logic is accessible to me, but we could set up an `IOOverrides` to hijack the socket creation.