### PR TITLE
ci: Provide a cache duration for the link checker

### DIFF
--- a/.github/workflows/check_broken_links.yaml
+++ b/.github/workflows/check_broken_links.yaml
@@ -17,18 +17,12 @@ jobs:
     - uses: actions/checkout@master
     - name: Check links
       id: check_links
-      uses: lycheeverse/lychee-action@v1.0.8
+      uses: lycheeverse/lychee-action@v1.2.0
       with:
+        format: detailed
+        fail: true # Fail the action if the link check fails
         args: >
           --config .github/workflows/link_check_config.lychee.toml
           **/*.md
           **/*.yaml
           **/*.dart
-    # lychee-action doesn't fail outright — we need to do it ourselves.
-    - name: Fail on broken links
-      if: steps.check_links.outputs.exit_code != 0
-      env:
-        EXIT_CODE: ${{ steps.check_links.outputs.exit_code }}
-      run: |
-        cat $LYCHEE_OUT
-        exit $EXIT_CODE

--- a/.github/workflows/link_check_config.lychee.toml
+++ b/.github/workflows/link_check_config.lychee.toml
@@ -3,6 +3,10 @@
 #
 # This config is referenced in the check_broken_links.yaml workflow.
 
+# Bump up timeouts and retries to avoid flakes
+max_retries = 5
+timeout = 40
+
 # Exclude fake or inaccessible URLs that are used in code or examples
 exclude = [
   "^https://test/$",


### PR DESCRIPTION
It's been complaining for the past few days (oddly, because this config hasn't changed), so I'm bumping to latest.

As a bonus, it looks like the lychee action can fail on its own now, so I was able to get rid of the extra step.