### PR TITLE
ci: Exclude nhost.io from link check

### DIFF
--- a/.github/workflows/link_check_config.lychee.toml
+++ b/.github/workflows/link_check_config.lychee.toml
@@ -7,11 +7,12 @@
 max_retries = 5
 timeout = 40
 
-# Exclude fake or inaccessible URLs that are used in code or examples
+# Exclude fake, inaccessible, or unchanging URLs that are used in code or examples
 exclude = [
   "^https://test/$",
   "^https://.*\\.nhost\\.app.*",
   "^http://localhost(:\\d+)?.*",
+  "^https://nhost.io/$",
 ]
 
 # Exclude all private IPs from checking


### PR DESCRIPTION
Seems like it's doing some kind of throttling, so let's give the top-level page a break.
