### PR TITLE
feat (nhost_sdk): include metadata in sign up options

### DIFF
--- a/packages/nhost_sdk/lib/src/api/auth_api_types.dart
+++ b/packages/nhost_sdk/lib/src/api/auth_api_types.dart
@@ -96,6 +96,7 @@ class User {
     required this.isAnonymous,
     required this.defaultRole,
     required this.roles,
+    required this.metadata,
     this.email,
     this.avatarUrl,
   });
@@ -112,6 +113,7 @@ class User {
   final bool isAnonymous;
   final String defaultRole;
   final List<String> roles;
+  final Map<String, Object?> metadata;
 
   static User fromJson(dynamic json) {
     return User(
@@ -126,6 +128,7 @@ class User {
       isAnonymous: json['isAnonymous'] as bool,
       defaultRole: json['defaultRole'] as String,
       roles: <String>[...json['roles']],
+      metadata: <String, Object?>{...json['metadata']},
     );
   }
 
@@ -139,6 +142,7 @@ class User {
       'createdAt': createdAt.toIso8601String(),
       'isAnonymous': isAnonymous,
       'defaultRole': defaultRole,
+      'metadata': metadata,
       'roles': roles,
     };
   }

--- a/packages/nhost_sdk/lib/src/auth_client.dart
+++ b/packages/nhost_sdk/lib/src/auth_client.dart
@@ -193,6 +193,7 @@ class AuthClient {
     required String password,
     String? locale,
     String? defaultRole,
+    Map<String, Object?>? metadata,
     List<String>? roles,
     String? displayName,
     String? redirectTo,
@@ -202,6 +203,7 @@ class AuthClient {
     final includeRoleOptions =
         defaultRole != null || (roles != null && roles.isNotEmpty);
     final options = {
+      if (metadata != null) 'metadata': metadata,
       if (locale != null) 'locale': locale,
       if (includeRoleOptions) 'defaultRole': defaultRole,
       if (includeRoleOptions) 'allowedRoles': roles,

--- a/packages/nhost_sdk/test/test_helpers.dart
+++ b/packages/nhost_sdk/test/test_helpers.dart
@@ -17,6 +17,7 @@ User createTestUser({required String id, required String email}) {
     defaultRole: 'user',
     roles: ['user'],
     isAnonymous: false,
+    metadata: { 'age': 14, 'height': 162 },
   );
 }
 


### PR DESCRIPTION
This PR adds the missing `metadata` field to the `signUp` function.