### PR TITLE
refreshTokenQueryParamName is changed

### DIFF
--- a/packages/nhost_sdk/lib/src/auth_client.dart
+++ b/packages/nhost_sdk/lib/src/auth_client.dart
@@ -37,7 +37,8 @@ const refreshTokenClientStorageKey = 'nhostRefreshToken';
 
 /// The query parameter name for the refresh token provided during OAuth
 /// provider-based sign-ins.
-const refreshTokenQueryParamName = 'refresh_token';
+// const refreshTokenQueryParamName = 'refresh_token';
+const refreshTokenQueryParamName = 'refreshToken';
 
 /// The Nhost authentication service.
 ///

--- a/packages/nhost_sdk/lib/src/auth_client.dart
+++ b/packages/nhost_sdk/lib/src/auth_client.dart
@@ -37,7 +37,6 @@ const refreshTokenClientStorageKey = 'nhostRefreshToken';
 
 /// The query parameter name for the refresh token provided during OAuth
 /// provider-based sign-ins.
-// const refreshTokenQueryParamName = 'refresh_token';
 const refreshTokenQueryParamName = 'refreshToken';
 
 /// The Nhost authentication service.


### PR DESCRIPTION
fix: The nhost callback refreshTokenQueryParamName is changed from `refresh_token` to `refreshToken`
