### PR TITLE
feat(nhost_sdk): Allow metadata to be passed in signInWithSmsPassword…

### DIFF
--- a/packages/nhost_auth_dart/lib/src/auth_client.dart
+++ b/packages/nhost_auth_dart/lib/src/auth_client.dart
@@ -310,12 +310,20 @@ class NhostAuthClient implements HasuraAuthClient {
   ///
   /// Throws an [NhostException] if sign in fails.
   @override
-  Future<void> signInWithSmsPasswordless(String phoneNumber) async {
+  Future<void> signInWithSmsPasswordless(
+    String phoneNumber, {
+    Map<String, Object?>? metadata,
+  }) async {
     log.finer('Attempting sign in (passwordless SMS)');
+
+    final options = {
+      if (metadata != null) 'metadata': metadata,
+    };
     await _apiClient.post(
       '/signin/passwordless/sms',
       jsonBody: {
         'phoneNumber': phoneNumber,
+        if (options.isNotEmpty) 'options': options,
       },
     );
   }

--- a/packages/nhost_auth_dart/lib/src/auth_client.dart
+++ b/packages/nhost_auth_dart/lib/src/auth_client.dart
@@ -310,8 +310,8 @@ class NhostAuthClient implements HasuraAuthClient {
   ///
   /// Throws an [NhostException] if sign in fails.
   @override
-  Future<void> signInWithSmsPasswordless(
-    String phoneNumber, {
+  Future<void> signInWithSmsPasswordless({
+    required String phoneNumber,
     String? locale,
     String? defaultRole,
     Map<String, Object?>? metadata,
@@ -331,7 +331,6 @@ class NhostAuthClient implements HasuraAuthClient {
       if (displayName != null) 'displayName': displayName,
       if (redirectTo != null) 'redirectTo': redirectTo,
     };
-
     await _apiClient.post(
       '/signin/passwordless/sms',
       jsonBody: {

--- a/packages/nhost_auth_dart/lib/src/auth_client.dart
+++ b/packages/nhost_auth_dart/lib/src/auth_client.dart
@@ -312,13 +312,26 @@ class NhostAuthClient implements HasuraAuthClient {
   @override
   Future<void> signInWithSmsPasswordless(
     String phoneNumber, {
+    String? locale,
+    String? defaultRole,
     Map<String, Object?>? metadata,
+    List<String>? roles,
+    String? displayName,
+    String? redirectTo,
   }) async {
     log.finer('Attempting sign in (passwordless SMS)');
 
+    final includeRoleOptions =
+        defaultRole != null || (roles != null && roles.isNotEmpty);
     final options = {
       if (metadata != null) 'metadata': metadata,
+      if (locale != null) 'locale': locale,
+      if (includeRoleOptions) 'defaultRole': defaultRole,
+      if (includeRoleOptions) 'allowedRoles': roles,
+      if (displayName != null) 'displayName': displayName,
+      if (redirectTo != null) 'redirectTo': redirectTo,
     };
+
     await _apiClient.post(
       '/signin/passwordless/sms',
       jsonBody: {

--- a/packages/nhost_sdk/lib/src/base/hasura_auth_client.dart
+++ b/packages/nhost_sdk/lib/src/base/hasura_auth_client.dart
@@ -44,7 +44,15 @@ abstract class HasuraAuthClient {
   });
 
   Future<void> signInAnonymous();
-  Future<void> signInWithSmsPasswordless(String phoneNumber);
+  Future<void> signInWithSmsPasswordless({
+    required String phoneNumber,
+    String? locale,
+    String? defaultRole,
+    Map<String, Object?>? metadata,
+    List<String>? roles,
+    String? displayName,
+    String? redirectTo,
+  });
 
   Future<AuthResponse> completeSmsPasswordlessSignIn(
     String phoneNumber,


### PR DESCRIPTION
Fixes #100 

Please note that I didn't add a test because currently the tests for SMS say "cannot meaningfully test" but please let me know if there is something that would be useful to add.
