### PR TITLE
feat(nhost_flutter_auth): Allow displayName and locale to be passed on signInAnonymous

### DIFF
--- a/packages/nhost_auth_dart/lib/src/auth_client.dart
+++ b/packages/nhost_auth_dart/lib/src/auth_client.dart
@@ -298,15 +298,31 @@ class NhostAuthClient implements HasuraAuthClient {
   Future<void> signInAnonymous(
     String? displayName,
     String? locale,
+    Map<String, dynamic>? metadata,
   ) async {
     log.finer('Attempting sign in anonymously');
-    await _apiClient.post(
-      '/signin/anonymous',
-      jsonBody: {
-        if (displayName != null) 'displayName': displayName,
-        if (locale != null) 'locale': locale,
-      },
-    );
+
+    AuthResponse? res;
+    try {
+      res = await _apiClient.post(
+        '/signin/anonymous',
+        jsonBody: {
+          if (displayName != null) 'displayName': displayName,
+          if (locale != null) 'locale': locale,
+          if (metadata != null) 'metadata': metadata
+        },
+        responseDeserializer: AuthResponse.fromJson,
+      );
+    } catch (e, st) {
+      log.finer('Sign in anonymously failed', e, st);
+      await clearSession();
+      rethrow;
+    }
+
+    if (res != null) {
+      log.finer('Sign in anonymously successful');
+      await setSession(res.session!);
+    }
   }
 
   /// Authenticates a user using a [phoneNumber].

--- a/packages/nhost_auth_dart/lib/src/auth_client.dart
+++ b/packages/nhost_auth_dart/lib/src/auth_client.dart
@@ -295,10 +295,17 @@ class NhostAuthClient implements HasuraAuthClient {
   /// Nhost dashboard -> settings -> Sign in methods -> Anonymous Users
   /// Throws an [NhostException] if sign in fails.
   @override
-  Future<void> signInAnonymous() async {
+  Future<void> signInAnonymous(
+    String? displayName,
+    String? locale,
+  ) async {
     log.finer('Attempting sign in anonymously');
     await _apiClient.post(
       '/signin/anonymous',
+      jsonBody: {
+        if (displayName != null) 'displayName': displayName,
+        if (locale != null) 'locale': locale,
+      },
     );
   }
 

--- a/packages/nhost_sdk/lib/src/base/hasura_auth_client.dart
+++ b/packages/nhost_sdk/lib/src/base/hasura_auth_client.dart
@@ -46,6 +46,7 @@ abstract class HasuraAuthClient {
   Future<void> signInAnonymous(
     String? displayName,
     String? locale,
+    Map<String, dynamic>? metadata,
   );
   Future<void> signInWithSmsPasswordless({
     required String phoneNumber,

--- a/packages/nhost_sdk/lib/src/base/hasura_auth_client.dart
+++ b/packages/nhost_sdk/lib/src/base/hasura_auth_client.dart
@@ -43,7 +43,10 @@ abstract class HasuraAuthClient {
     String? redirectTo,
   });
 
-  Future<void> signInAnonymous();
+  Future<void> signInAnonymous(
+    String? displayName,
+    String? locale,
+  );
   Future<void> signInWithSmsPasswordless({
     required String phoneNumber,
     String? locale,


### PR DESCRIPTION
Added this PR with regards to https://github.com/nhost/hasura-auth/blob/main/src/routes/signin/anonymous.ts that allows user to send displayName and locale to override the default "Anonymous User". Also, session should be set after signing in.