### PR TITLE
dependencies upgrade (#130)

### DIFF
--- a/packages/nhost_gql_links/pubspec.yaml
+++ b/packages/nhost_gql_links/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nhost_gql_links
-version: 4.0.1
+version: 4.0.2
 description: Constructs GraphQL links for use with graphql and ferry packages
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_gql_links
@@ -12,7 +12,7 @@ dependencies:
   gql_exec: ^1.0.0
   gql_http_link: ^1.0.1
   gql_link: ^1.0.0
-  gql_websocket_link: ^1.1.0
+  gql_websocket_link: ^2.0.1
   gql: ^1.0.0
   http: ^1.1.0
   logging: ^1.1.0

--- a/packages/nhost_storage_dart/lib/src/api/storage_api_types.dart
+++ b/packages/nhost_storage_dart/lib/src/api/storage_api_types.dart
@@ -1,4 +1,3 @@
-/// Describes a file stored by Nhost.
 import 'package:nhost_sdk/nhost_sdk.dart';
 
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,9 +5,9 @@ homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart
 
 environment:
-  sdk: ">=2.14.0 <=3.1.5"
+  sdk: ">=2.14.0 <=3.2.5"
 
 dev_dependencies:
   dotenv: ^4.2.0
-  melos: ^3.2.0
+  melos: ^4.0.0
   path: ^1.8.3


### PR DESCRIPTION
fix: dependencies update
@nhost_gql_links
- gql_websocket_link@ ^2.0.1

@nhost
sdk@ >=2.14.0 <=3.2.5 
- melos@4.0.0
