### PR TITLE
chore(release): Publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-11-05
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`nhost_dart` - `v2.2.0`](#nhost_dart---v220)
+ - [`nhost_sdk` - `v5.8.0`](#nhost_sdk---v580)
+ - [`nhost_storage_dart` - `v2.2.0`](#nhost_storage_dart---v220)
+ - [`nhost_flutter_auth` - `v4.2.1`](#nhost_flutter_auth---v421)
+ - [`nhost_flutter_graphql` - `v3.1.2`](#nhost_flutter_graphql---v312)
+ - [`nhost_graphql_adapter` - `v4.0.10`](#nhost_graphql_adapter---v4010)
+ - [`nhost_functions_dart` - `v2.0.10`](#nhost_functions_dart---v2010)
+ - [`nhost_auth_dart` - `v2.6.1`](#nhost_auth_dart---v261)
+ - [`nhost_gql_links` - `v4.0.11`](#nhost_gql_links---v4011)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `nhost_flutter_auth` - `v4.2.1`
+ - `nhost_flutter_graphql` - `v3.1.2`
+ - `nhost_graphql_adapter` - `v4.0.10`
+ - `nhost_functions_dart` - `v2.0.10`
+ - `nhost_auth_dart` - `v2.6.1`
+ - `nhost_gql_links` - `v4.0.11`
+
+---
+
+#### `nhost_dart` - `v2.2.0`
+
+ - **FEAT**(storage): added replaceFile method (#172).
+
+#### `nhost_sdk` - `v5.8.0`
+
+ - **FEAT**(storage): added replaceFile method (#172).
+
+#### `nhost_storage_dart` - `v2.2.0`
+
+ - **FEAT**(storage): added replaceFile method (#172).
+
+
 ## 2025-10-13
 
 ### Changes

--- a/packages/nhost_auth_dart/CHANGELOG.md
+++ b/packages/nhost_auth_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+ - Update a dependency to the latest release.
+
 ## 2.6.0
 
  - **FEAT**: added deanonymizeUser (#166).

--- a/packages/nhost_auth_dart/pubspec.yaml
+++ b/packages/nhost_auth_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nhost_auth_dart
 description: Nhost Dart Auth Service SDK
-version: 2.6.0
+version: 2.6.1
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_sdk
 issue_tracker: https://github.com/nhost/nhost-dart/issues
@@ -14,7 +14,7 @@ dependencies:
   logging: ^1.1.0
   meta: ^1.7.0
   #Nhost_sdk
-  nhost_sdk: ^5.7.0
+  nhost_sdk: ^5.8.0
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/nhost_dart/CHANGELOG.md
+++ b/packages/nhost_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+ - **FEAT**(storage): added replaceFile method (#172).
+
 ## 2.1.0
 
  - **FEAT**(storage): update SDK to use modern way of uploading files (#167).

--- a/packages/nhost_dart/pubspec.yaml
+++ b/packages/nhost_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nhost_dart
 description: Nhost Dart SDK
-version: 2.1.0
+version: 2.2.0
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_sdk
 issue_tracker: https://github.com/nhost/nhost-dart/issues
@@ -16,11 +16,11 @@ dependencies:
   path: ^1.8.0
 
   #NHOST Package
-  nhost_sdk: ^5.7.0
-  nhost_storage_dart: ^2.1.0
-  nhost_auth_dart: ^2.6.0
-  nhost_functions_dart: ^2.0.9
-  nhost_graphql_adapter: ^4.0.9
+  nhost_sdk: ^5.8.0
+  nhost_storage_dart: ^2.2.0
+  nhost_auth_dart: ^2.6.1
+  nhost_functions_dart: ^2.0.10
+  nhost_graphql_adapter: ^4.0.10
 dev_dependencies:
   fake_async: ^1.3.1
   graphql: ^5.2.3
@@ -33,7 +33,7 @@ dev_dependencies:
   test: ^1.22.0
   gql: ^1.0.0
   gql_exec: ^1.0.0
-  nhost_gql_links: ^4.0.10
+  nhost_gql_links: ^4.0.11
   async: ^2.10.0
   stream_channel: ^2.1.1
   web_socket_channel: ^3.0.0

--- a/packages/nhost_flutter_auth/CHANGELOG.md
+++ b/packages/nhost_flutter_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.1
+
+ - Update a dependency to the latest release.
+
 ## 4.2.0
 
  - **FEAT**(storage): update SDK to use modern way of uploading files (#167).

--- a/packages/nhost_flutter_auth/pubspec.yaml
+++ b/packages/nhost_flutter_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: nhost_flutter_auth
 description: >
   Provides Nhost authentication state to your Flutter app, making it easy to set
   up protected resources, and react to sign ins and sign outs.
-version: 4.2.0
+version: 4.2.1
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_flutter_auth
 issue_tracker: https://github.com/nhost/nhost-dart/issues
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   #Nhost_dart
-  nhost_dart: ^2.1.0
+  nhost_dart: ^2.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/nhost_flutter_graphql/CHANGELOG.md
+++ b/packages/nhost_flutter_graphql/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+
+ - Update a dependency to the latest release.
+
 ## 3.1.1
 
  - Update a dependency to the latest release.

--- a/packages/nhost_flutter_graphql/pubspec.yaml
+++ b/packages/nhost_flutter_graphql/pubspec.yaml
@@ -2,7 +2,7 @@ name: nhost_flutter_graphql
 description: >
   Provides GraphQL clients to your Flutter application, automatically configured
   to work with Nhost
-version: 3.1.1
+version: 3.1.2
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_flutter_graphql
 issue_tracker: https://github.com/nhost/nhost-dart/issues
@@ -18,7 +18,7 @@ dependencies:
   logging: ^1.1.0
 
   #Nhost_dart
-  nhost_flutter_auth: ^4.2.0
+  nhost_flutter_auth: ^4.2.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/nhost_functions_dart/CHANGELOG.md
+++ b/packages/nhost_functions_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10
+
+ - Update a dependency to the latest release.
+
 ## 2.0.9
 
  - Update a dependency to the latest release.

--- a/packages/nhost_functions_dart/pubspec.yaml
+++ b/packages/nhost_functions_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nhost_functions_dart
 description: Nhost Dart Functions Service SDK
-version: 2.0.9
+version: 2.0.10
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_sdk
 issue_tracker: https://github.com/nhost/nhost-dart/issues
@@ -13,7 +13,7 @@ dependencies:
   http: ^1.1.0
   logging: ^1.1.0
   #Nhost_sdk
-  nhost_sdk: ^5.7.0
+  nhost_sdk: ^5.8.0
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/nhost_gql_links/CHANGELOG.md
+++ b/packages/nhost_gql_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.11
+
+ - Update a dependency to the latest release.
+
 ## 4.0.10
 
  - Update a dependency to the latest release.

--- a/packages/nhost_gql_links/pubspec.yaml
+++ b/packages/nhost_gql_links/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nhost_gql_links
-version: 4.0.10
+version: 4.0.11
 description: Constructs GraphQL links for use with graphql and ferry packages
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_gql_links
@@ -20,7 +20,7 @@ dependencies:
   web_socket_channel: ^3.0.0
 
   #Nhost_dart
-  nhost_sdk: ^5.7.0
+  nhost_sdk: ^5.8.0
 dev_dependencies:
   async: ^2.10.0
   fake_async: ^1.3.1

--- a/packages/nhost_graphql_adapter/CHANGELOG.md
+++ b/packages/nhost_graphql_adapter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.10
+
+ - Update a dependency to the latest release.
+
 ## 4.0.9
 
  - Update a dependency to the latest release.

--- a/packages/nhost_graphql_adapter/example/pubspec.yaml
+++ b/packages/nhost_graphql_adapter/example/pubspec.yaml
@@ -10,6 +10,6 @@ dependencies:
   graphql: ^5.1.3
 
   # Nhost packages
-  nhost_dart: ^2.1.0
+  nhost_dart: ^2.2.0
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/nhost_graphql_adapter/pubspec.yaml
+++ b/packages/nhost_graphql_adapter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nhost_graphql_adapter
-version: 4.0.9
+version: 4.0.10
 description: Easily connect to your Nhost.io GraphQL backend using the graphql package.
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_graphql_adapter
@@ -14,8 +14,8 @@ dependencies:
   meta: ^1.7.0
 
   #Nhost_dart
-  nhost_gql_links: ^4.0.10
-  nhost_sdk: ^5.7.0
+  nhost_gql_links: ^4.0.11
+  nhost_sdk: ^5.8.0
 dev_dependencies:
   async: ^2.10.0
   lints: ^5.1.1

--- a/packages/nhost_sdk/CHANGELOG.md
+++ b/packages/nhost_sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.0
+
+ - **FEAT**(storage): added replaceFile method (#172).
+
 ## 5.7.0
 
  - **FEAT**(storage): update SDK to use modern way of uploading files (#167).

--- a/packages/nhost_sdk/pubspec.yaml
+++ b/packages/nhost_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nhost_sdk
 description: Nhost authentication and file storage/retrieval APIs for the Dart language.
-version: 5.7.0
+version: 5.8.0
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_sdk
 issue_tracker: https://github.com/nhost/nhost-dart/issues

--- a/packages/nhost_storage_dart/CHANGELOG.md
+++ b/packages/nhost_storage_dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+ - **FEAT**(storage): added replaceFile method (#172).
+
 ## 2.1.0
 
  - **FEAT**(storage): update SDK to use modern way of uploading files (#167).

--- a/packages/nhost_storage_dart/example/pubspec.yaml
+++ b/packages/nhost_storage_dart/example/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
   # Nhost packages
   nhost_storage_dart:
     path: ../
-  nhost_auth_dart: ^2.6.0
+  nhost_auth_dart: ^2.6.1

--- a/packages/nhost_storage_dart/pubspec.yaml
+++ b/packages/nhost_storage_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nhost_storage_dart
 description: Nhost Dart Storage Service SDK
-version: 2.1.0
+version: 2.2.0
 homepage: https://nhost.io
 repository: https://github.com/nhost/nhost-dart/tree/main/packages/nhost_sdk
 issue_tracker: https://github.com/nhost/nhost-dart/issues
@@ -13,7 +13,7 @@ dependencies:
   http: ^1.1.0
 
   #Nhost_sdk
-  nhost_sdk: ^5.7.0
+  nhost_sdk: ^5.8.0
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0


### PR DESCRIPTION
 - nhost_dart@2.2.0
 - nhost_sdk@5.8.0
 - nhost_storage_dart@2.2.0
 - nhost_flutter_auth@4.2.1
 - nhost_flutter_graphql@3.1.2
 - nhost_graphql_adapter@4.0.10
 - nhost_functions_dart@2.0.10
 - nhost_auth_dart@2.6.1
 - nhost_gql_links@4.0.11